### PR TITLE
SPI-Speed problem with Particle Photon

### DIFF
--- a/firmware/SparkFunLSM9DS1.cpp
+++ b/firmware/SparkFunLSM9DS1.cpp
@@ -1043,8 +1043,8 @@ void LSM9DS1::initSPI()
 	digitalWrite(_mAddress, HIGH);
 	
 	SPI.begin();
-	// Maximum SPI frequency is 10MHz, could divide by 2 here:
-	SPI.setClockDivider(SPI_CLOCK_DIV2);
+	// Maximum SPI frequency is 10MHz:
+	SPI.setClockDivider(SPI_CLOCK_DIV4); // Photon requires min. DIV4
 	// Data is read and written MSb first.
 	SPI.setBitOrder(MSBFIRST);
 	// Data is captured on rising edge of clock (CPHA = 0)

--- a/spark.json
+++ b/spark.json
@@ -2,6 +2,6 @@
   "name": "SparkFunLSM9DS1",
   "author": "Jim Lindblom <jim@sparkfun.com>",
   "license": "MIT",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A library to drive the LSM9DS1 9DoF."
 }


### PR DESCRIPTION
During a [discussion on the Particle forum](https://community.particle.io/t/how-to-use-spi-mode-in-photon-imu-shield/17309/7) about SPI support of the `SparkFun Photon IMU Shield` I faced some issues.
First I had problems with one of my shields (it seems to have a short between the CS.A/G and CS M pin on a non-visible location, possibly underneath the chip), but after trying on another one I found that the OPs problem was due to a too high SPI speed.
With SPI_CLOCK_DIV4 (instead of SPI_CLOCK_DIV2) the lib works.

An alternative, more elaborate fix that targets max. speed on different Particle devices would look like this

```
#if defined(SYSTEM_VERSION_045)
  SPI.setClockSpeed(10, MHZ);
#elif defined(STM32F2XX)
  SPI.setClockDivider(SPI_CLOCK_DIV4);  // Photon/P0/P1/Electron
#elif defined(STM32F10X_MD)
  SPI.setClockDivider(SPI_CLOCK_DIV2);  // Core
#else
  SPI.setClockDivider(SPI_CLOCK_DIV16);  // just to be on the safe side
#endif
```

---

PS: Is there anything I can do about my faulty shield?
