### PR TITLE
Electron compatible library

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Repository Contents
 * **/doc** - Additional documentation for the user. These files are ignored by the IDE. 
 * **/firmware** - Source files for the library (.cpp, .h).
 * **/firmware/examples** - Example sketches for the library (.cpp). Run these from the Particle IDE. 
-* **spark.json** - General library properties for the Particel library manager. 
+* **spark.json** - General library properties for the Particle library manager. 
 
 Example Usage
 -------------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Repository Contents
 * **/doc** - Additional documentation for the user. These files are ignored by the IDE. 
 * **/firmware** - Source files for the library (.cpp, .h).
 * **/firmware/examples** - Example sketches for the library (.cpp). Run these from the Particle IDE. 
-* **spark.json** - General library properties for the Particle library manager. 
+* **library.properties** - General library properties for the Particle library manager. 
 
 Example Usage
 -------------------

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,7 @@
+name=SparkFunLSM9DS1
+version=1.1.4
+author=Jim Lindblom <jim@sparkfun.com>
+license=MIT
+sentence=A library to drive the LSM9DS1 9DoF
+paragraph=The LSM9DS1 DoF is an IMU shield originally for the particle photon and also usable on other hardware boards including the particle electron. This library enables the simple use of the LSM9DS1 9DoF as an IMU for an internet connected device
+architectures=*


### PR DESCRIPTION
Hi,

-- This is my first contribution to an open source project so go easy on me! --

I saw ScruffR's comment on this thread about shields being compatible between the particle photon and electron. However I found that this library could not be used with an electron.

https://community.particle.io/t/shields-for-the-electron/27813/5

I have attempted to make the library compatible with a wider range of devices by upgrading the spark.json file to a library.properties file and defining the library there as being compatible with all hardware boards.

Please let me know what you think, perhaps I should test this new library with an electron before it can be merged?

Thanks,
Arthur
